### PR TITLE
Apply billing rules to all users in production

### DIFF
--- a/api/app/lib/relay/feature_gater.rb
+++ b/api/app/lib/relay/feature_gater.rb
@@ -16,11 +16,7 @@ module Relay
     def enabled?(feature_name)
       case feature_name
       when :billing
-        !Rails.env.production? || user.email.split("@").last.in?(%w[
-          relaywireless.com
-          relaydevice.com
-          dewi.org
-        ])
+        true
       else
         raise "Unknown feature: #{feature_name}"
       end

--- a/api/spec/models/relay/user_spec.rb
+++ b/api/spec/models/relay/user_spec.rb
@@ -15,38 +15,23 @@ RSpec.describe User, type: :model do
   end
 
   describe "#plan" do
-    context "when in production" do
-      it "always returns the Beta plan" do
-        allow(Rails.env).to receive(:production?).and_return(true)
-        user = create_user_with_payment_processor(plan_id: "professional")
+    context "when the user is not subscribed" do
+      it "returns the Community plan" do
+        user = create_user_with_payment_processor(plan_id: nil)
 
         plan = user.plan
 
-        expect(plan.id).to eq("beta")
+        expect(plan.id).to eq("community")
       end
     end
 
-    context "when in development" do
-      context "when the user is not subscribed" do
-        it "returns the Community plan" do
-          allow(Rails.env).to receive(:production?).and_return(false)
-          user = create_user_with_payment_processor(plan_id: nil)
+    context "when the user is subscribed" do
+      it "returns the plan associated with the subscription" do
+        user = create_user_with_payment_processor(plan_id: "enthusiast")
 
-          plan = user.plan
+        plan = user.plan
 
-          expect(plan.id).to eq("community")
-        end
-      end
-
-      context "when the user is subscribed" do
-        it "returns the plan associated with the subscription" do
-          allow(Rails.env).to receive(:production?).and_return(false)
-          user = create_user_with_payment_processor(plan_id: "enthusiast")
-
-          plan = user.plan
-
-          expect(plan.id).to eq("enthusiast")
-        end
+        expect(plan.id).to eq("enthusiast")
       end
     end
   end


### PR DESCRIPTION
## Summary

- Fix the `:billing` gate in `Relay::FeatureGater` so it returns `true` for every user. Previously it was disabled in production for any email outside `(relaywireless.com, relaydevice.com, dewi.org)`, which short-circuited `User#plan_id` to the hidden `"beta"` plan (10k calls/mo, unlimited lookback, aggregate endpoints) regardless of Stripe state.
- Update `User#plan` specs accordingly — drop the `"when in production / always returns Beta"` test which codified the bug, and consolidate the env-specific contexts since plan resolution no longer branches on `Rails.env`.

## Why

Audit showed 208 of 212 active users on `beta`, only 1 paying customer. The `community` free tier was unreachable for external signups, so there was no incentive to upgrade. After this change unsubscribed users land on `community` (1k/mo, 30d lookback, no aggregates); subscribed users get the plan their Stripe lookup_key maps to. Beta stays in the catalog with `visible: false`, reachable only via `User.with_stubbed_plan` (test-only).

## Customer impact

Tightens limits on the ~207 external `beta` users immediately upon deploy. Per direction the intent is to enforce 1k right away; a follow-up reset (`current_api_usage` → 0, `api_usage_reset_at` → now) will run after deploy so each user starts a fresh 30-day window.

## Test plan

- [ ] CI: rspec + rubocop + spoom srb tc + brakeman
- [ ] Post-merge sanity in prod: `User.find_by(email: "vigilhay@msu.edu").plan.id` returns `"community"`