### PR TITLE
Fix Dashboard: remove GraphQL wording, remove Discord button, correct E…

### DIFF
--- a/api/app/lib/relay/billing/plan.rb
+++ b/api/app/lib/relay/billing/plan.rb
@@ -47,7 +47,7 @@ module Relay
               id: "enthusiast",
               name: "Enthusiast",
               description: "Ideal for growing businesses that need better rate limits and lookback windows.",
-              price_per_month: 49.99,
+              price_per_month: 59.99,
               visible: true,
               features: [
                 Features::ApiAccess.new(calls_per_month: 10_000),

--- a/api/app/views/dashboard/show.html.erb
+++ b/api/app/views/dashboard/show.html.erb
@@ -9,19 +9,13 @@
   <% end %>
 
   <%= render(CardComponent.new(title: "Getting Started")) do %>
-    <p class="text-gray-600 mb-6">Welcome to the Relay GraphQL API for Helium Oracle data! This API allows you to easily query information about any Helium hotspot, including essential details, earnings, and historical data.</p>
+    <p class="text-gray-600 mb-6">Welcome to the Relay API for Helium Oracle data! This API allows you to easily query information about any Helium hotspot, including essential details, earnings, and historical data.</p>
 
     <div class="flex gap-4">
       <%= render(ButtonComponent.new(
         text: "Read Docs",
         style: :secondary,
         href: "https://docs.relaywireless.com",
-        target: "_blank"
-      )) %>
-      <%= render(ButtonComponent.new(
-        text: "Join Relay Discord",
-        style: :secondary,
-        href: "https://discord.com/channels/404106811252408320/1368978610907513042",
         target: "_blank"
       )) %>
     </div>

--- a/api/spec/system/dashboard_spec.rb
+++ b/api/spec/system/dashboard_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe "Dashboard", type: :system do
   it "displays the dashboard" do
     sign_in create(:user), scope: :user
     visit root_path
-    expect(page).to have_content("Welcome to the Relay GraphQL API for Helium Oracle data!")
+    expect(page).to have_content("Welcome to the Relay API for Helium Oracle data!")
   end
 end


### PR DESCRIPTION
## Summary
- Getting Started copy no longer references **GraphQL** (the API isn't pitched as GraphQL anymore).
- Removed the redundant **Join Relay Discord** button under Getting Started — the Discord channel is still surfaced in the beta-banner card above.
- Corrected the displayed **Enthusiast** plan price from **\$49.99** → **\$59.99**/mo.

Files touched:
- `api/app/views/dashboard/show.html.erb`
- `api/app/lib/relay/billing/plan.rb`