### PR TITLE
Bump brakeman 7.1.0 -> 8.0.4 to unblock CI and deploys

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       blueprinter (~> 1.0)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## What this PR does

One-line bump in `api/Gemfile.lock`: `brakeman (7.1.0)` → `brakeman (8.0.4)`.

## Why

`api/bin/brakeman` injects `--ensure-latest`, which causes Brakeman to exit with code 5 if the bundled version is not the latest published on rubygems. Brakeman 8.0.4 has been the latest for some time, so the bundled 7.1.0 has been failing the version check on every CI run.

Because the deploy job in `.github/workflows/ci.yml` is gated on `needs: [lint-ruby, ...]`, this Brakeman failure has been silently blocking production deploys for several months. The last successful CI run on `main` was on 2025-09-15 (SHA `1fb10d5d`). Every merge to `main` since then has run CI but skipped deploy because Brakeman fails before the actual scan even starts.

## Verification

Ran Brakeman 8.0.4 standalone (outside the bundle, via vanilla Ruby 3.4 image) against the current `api/` tree:

```
Errors: 0
Security Warnings: 0
No warnings found
```

Then ran with the same flags CI uses (`--ensure-latest --no-pager`):

```
Errors: 0
Security Warnings: 0
No warnings found
EXIT: 0
```

So this is a pure version bump — the existing app passes Brakeman 8.0.4 with zero findings. Brakeman 8.0.4's only runtime dependency is `racc` (identical to 7.1.0), so only the version line in `Gemfile.lock` changes.

## ⚠️ Deploy implications

Once this merges to `main` and CI goes green, the next push to `main` will trigger the `deploy` job, which will deploy **every change merged since 2025-09-15** to ECS in one shot. That's several months of accumulated commits including PR #582 ("Apply billing rules to all users in production") and PR #584 (Dashboard UI fixes / Enthusiast price). Worth coordinating before merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)