### PR TITLE
Add CODEOWNERS to require @elijahbilokur review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Global code owner: every PR will auto-request review from @elijahbilokur.
+# Combined with branch protection's "Require review from Code Owners",
+# this enforces approval from @elijahbilokur on all contributions.
+* @elijahbilokur


### PR DESCRIPTION
Sets @elijahbilokur as the global code owner so every PR automatically requests their review. Pair with a branch protection rule that has "Require review from Code Owners" enabled to enforce approval.