### PR TITLE
Dashboard cleanup: remove beta callout, drop Oracle wording, simplify Community tier

### DIFF
--- a/api/app/lib/relay/billing/features/customer_service.rb
+++ b/api/app/lib/relay/billing/features/customer_service.rb
@@ -12,7 +12,7 @@ module Relay
 
             sig { returns(Tier) }
             def community
-              new(name: "Community support", description: "Community-based support in our Discord")
+              new(name: "Community support", description: "Community-based support")
             end
 
             sig { returns(Tier) }

--- a/api/app/views/dashboard/show.html.erb
+++ b/api/app/views/dashboard/show.html.erb
@@ -1,15 +1,8 @@
 <% content_for :title, "Dashboard" %>
 
 <div class="space-y-4">
-  <%= render(CardComponent.new(
-    title: "The Relay API is in beta!",
-    color: :amber
-  )) do %>
-    <p class="text-gray-600">The API might have issues, bugs, and imperfections. We welcome any feedback in our official Helium Discord channel.</p>
-  <% end %>
-
   <%= render(CardComponent.new(title: "Getting Started")) do %>
-    <p class="text-gray-600 mb-6">Welcome to the Relay API for Helium Oracle data! This API allows you to easily query information about any Helium hotspot, including essential details, earnings, and historical data.</p>
+    <p class="text-gray-600 mb-6">Welcome to the Relay API for Helium data! This API allows you to easily query information about any Helium hotspot, including essential details, earnings, and historical data.</p>
 
     <div class="flex gap-4">
       <%= render(ButtonComponent.new(

--- a/api/spec/system/dashboard_spec.rb
+++ b/api/spec/system/dashboard_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe "Dashboard", type: :system do
   it "displays the dashboard" do
     sign_in create(:user), scope: :user
     visit root_path
-    expect(page).to have_content("Welcome to the Relay API for Helium Oracle data!")
+    expect(page).to have_content("Welcome to the Relay API for Helium data!")
   end
 end


### PR DESCRIPTION
## Summary
- **Remove the \"Relay API is in beta!\" callout card** from the dashboard; the API is no longer in beta.
- **Drop \"Oracle\" from the Getting Started copy** (\"Helium Oracle data\" → \"Helium data\") since Relay also serves on-chain data from Solana.
- **Update the Community plan tier description** from \"Community-based support in our Discord\" → \"Community-based support\", removing Discord references in line with the rest of the dashboard.
- **Update dashboard system spec** to match the new Getting Started copy.

Files touched:
- \`api/app/views/dashboard/show.html.erb\` — beta callout removed, \"Oracle\" dropped
- \`api/app/lib/relay/billing/features/customer_service.rb\` — Community tier description
- \`api/spec/system/dashboard_spec.rb\` — assertion updated to new copy

## Out of scope (flagging only)
The layout meta tags at \`api/app/views/layouts/application.html.erb:11-12\` still describe the API as \"GraphQL API for Helium Oracle data\". Leaving those for a separate change unless asked.

## Test plan
- [ ] Render dashboard locally signed in:
  - [ ] No \"Relay API is in beta!\" callout at the top of the page.
  - [ ] Getting Started reads \"Welcome to the Relay API for Helium data!\" (no \"Oracle\", no \"GraphQL\").
  - [ ] Community plan card's last benefit reads \"Community-based support\" (no Discord).
- [ ] \`docker-compose exec web bundle exec rspec spec/system/dashboard_spec.rb\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)